### PR TITLE
Add the name of the attempted-resolved service to exception

### DIFF
--- a/Alun.AutoFac.Validation/AutofacExtensions.cs
+++ b/Alun.AutoFac.Validation/AutofacExtensions.cs
@@ -59,7 +59,10 @@ namespace Autofac
                 }
                 catch (DependencyResolutionException ex)
                 {
-                    exceptions.Add(ex);
+                    var e = new DependencyResolutionException(
+                        string.Format("Unable to resolve service '{0}'. {1}",
+                            typedService.ServiceType.FullName, ex.Message), ex);
+                    exceptions.Add(e);
                 }
             }
             return exceptions;

--- a/Alun.Autofac.Validation.Test/ValidationTests.cs
+++ b/Alun.Autofac.Validation.Test/ValidationTests.cs
@@ -81,6 +81,7 @@ namespace Alun.Autofac.Validation.Test
             var container = builder.Build();
 
             var result = container.FindConfigurationProblems();
+            Assert.IsTrue(result[0].Message.Contains("Unable to resolve service 'Foo.IRepository'."), result[0].Message);
             Assert.IsTrue(result[0].Message.Contains("None of the constructors found with 'Public binding flags' on type 'Bar.Repository' can be invoked with the available services and parameters"), result[0].Message);
             Assert.AreEqual(1, result.Count);
         }
@@ -93,6 +94,7 @@ namespace Alun.Autofac.Validation.Test
             var container = builder.Build();
 
             var result = container.FindConfigurationProblems();
+            Assert.IsTrue(result[0].Message.Contains("Unable to resolve service 'Bar.MyService'."), result[0].Message);
             Assert.IsTrue(result[0].Message.Contains("None of the constructors found with 'Public binding flags' on type 'Bar.MyService' can be invoked with the available services and parameters"), result[0].Message);
             Assert.AreEqual(1, result.Count);            
         }


### PR DESCRIPTION
Some Autofac exception messages don't specify which service has a
configuration problem (e.g. MatchingScopeNotFound) which makes debugging
test failures more difficult.

To aid debugging, prepend the typedService's FullName to the exception
message and add the original exception as the InnerException.
